### PR TITLE
Add Proper Citation Docs

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,10 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+authors:
+- family-names: "Gula"
+  given-names: "Cordet"
+  orcid: "https://orcid.org/0009-0003-9518-7022"
+title: "Aurallusion"
+version: 0.1.0
+date-released: 2025-01-19
+url: "https://github.com/CordetG/aurallusion"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,10 +1,14 @@
 cff-version: 1.2.0
 message: "If you use this software, please cite it as below."
 authors:
-- family-names: "Gula"
-  given-names: "Cordet"
-  orcid: "https://orcid.org/0009-0003-9518-7022"
+  - family-names: "Gula"
+    given-names: "Cordet"
+    orcid: "https://orcid.org/0009-0003-9518-7022"
 title: "Aurallusion"
 version: 0.1.0
 date-released: 2025-01-19
 url: "https://github.com/CordetG/aurallusion"
+references:
+  - type: "text"
+    title: "Full list of references"
+    url: "https://github.com/CordetG/aurallusion/docs/REFERENCES.md"

--- a/docs/REFERENCES.md
+++ b/docs/REFERENCES.md
@@ -1,0 +1,12 @@
+# References
+
+## Cited in Documentation
+
+[1]: Munsell Color (2019, June 27). Neil Harbisson: Hearing Colors. Munsell Color Blog. Retrieved June 15, 2023, from https://munsell.com/color-blog/neil-harbisson-hearing-colors/
+
+## Uncited Resources
+
++ [Naming Conventions for Git Branches](https://medium.com/@abhay.pixolo/naming-conventions-for-git-branches-a-cheatsheet-8549feca2534)
++ [Github Docs - Create Branch for Issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/creating-a-branch-for-an-issue)
++ [Beginner's Guide to Github - Creating a Pull Request](https://github.blog/developer-skills/github/beginners-guide-to-github-creating-a-pull-request/)
++ [Github Docs - About Citation Files](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files)

--- a/references.txt
+++ b/references.txt
@@ -1,1 +1,0 @@
-[1]: Munsell Color (2019, June 27). Neil Harbisson: Hearing Colors. Munsell Color Blog. Retrieved June 15, 2023, from https://munsell.com/color-blog/neil-harbisson-hearing-colors/


### PR DESCRIPTION
This PR adds the appropriate citation docs for citing this project with the CITATION.cff file. The CITATION.cff file references a markdown file, docs/REFERENCES.md which holds the list of external references used to support the development of this project. The previous references.txt file has been removed.